### PR TITLE
Add atom like key params to add-listeners!/remove-listeners!

### DIFF
--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -126,7 +126,7 @@
 
     (testing "can register listener and register is called"
       (reset! calls 0)
-      (swap! store add-listener! :account/create counting-listener)
+      (swap! store add-listener! :account/create ::counting-listener counting-listener)
       (mutate! @store :account/create {:account/name  "a3"
                                        :account/state :active})
       (is (= 1 @calls)))
@@ -134,8 +134,8 @@
 
     (testing "can remove a listener and register is not called anymore"
       (reset! calls 0)
-      (swap! store add-listener!    :account/create counting-listener)
-      (swap! store remove-listener! :account/create counting-listener)
+      (swap! store add-listener!    :account/create ::counting-listener counting-listener)
+      (swap! store remove-listener! :account/create ::counting-listener)
       (mutate! @store :account/create {:account/name  "a3"
                                        :account/state :active})
 
@@ -144,8 +144,8 @@
   (testing "removing a listener that was not registered doesn't have side-effects"
     (let [listener2 (constantly nil)]
       (reset! calls 0)
-      (swap! store add-listener!    :account/create counting-listener)
-      (swap! store remove-listener! :account/create listener2)
+      (swap! store add-listener!    :account/create ::counting-listener counting-listener)
+      (swap! store remove-listener! :account/create ::not-registered)
       (mutate! @store :account/create {:account/name  "a3"
                                        :account/state :active})
 

--- a/test/seql/readme_test.clj
+++ b/test/seql/readme_test.clj
@@ -268,7 +268,10 @@
           store-result (fn [details]
                          (reset! last-result
                                  (select-keys details [:mutation :result])))
-          env          (add-listener! env :account/create store-result)]
+          env          (add-listener! env
+                                      :account/create
+                                      ::handler
+                                      store-result)]
 
       (mutate! env :account/create {:account/name "a4" :account/state :active})
 


### PR DESCRIPTION
I pondered whether I should also add a simplified arity where the mutation is the key, but I am not sure, it makes a bit odd maybe and I rather follow atom style watches api and have only one way to do it. 

something like: 

```clj
(defn add-listener!
  "Given an environment, add a mutation handler.
  The handlers is bound by `key`, if specified, otherwise the `key` will
  default to the mutation key. Yields an updated environment"
  ([env mutation handler]
   (add-listener! env mutation mutation handler))
  ([env mutation key handler]
   (let [entity (-> mutation namespace keyword)]
     (assoc-in env [:schema entity :listeners mutation key] handler))))

(defn remove-listener!
  "Given an environment, remove a mutation handler by `key` if
  specified, otherwise it will remove a handler that match the
  mutation `key`. Yields an updated environment."
  ([env mutation]
   (remove-listener! env mutation mutation))
  ([env mutation key]
   (let [entity (-> mutation namespace keyword)]
     (update-in env [:schema entity :listeners mutation] dissoc key))))
```