### PR TITLE
Throw on double registration for same key + unqualify changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "ISC"}
   :dependencies [[org.clojure/clojure   "1.10.1"]
                  [org.clojure/java.jdbc "0.7.10"]
-                 [honeysql              "0.9.6"]
+                 [honeysql              "0.9.8"]
                  [camel-snake-kebab     "0.4.0"]]
   :plugins [[lein-codox "0.10.7"]]
   :aliases {"kaocha" ["with-profile" "+dev" "run" "-m" "kaocha.runner"]}

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -269,7 +269,7 @@
   ([env entity fields]
    (query env entity fields []))
   ([env entity fields conditions]
-   {:pre [(s/valid? ::query-args [env entity fields conditions])]}
+   (s/assert ::query-args [env entity fields conditions])
    (let [[q qmeta] (sql-query env entity fields conditions)]
      (->> (sql/format q)
           (jdbc/query (:jdbc env))
@@ -298,17 +298,13 @@
   (let [entity (-> mutation namespace keyword)]
     (or (get-in env [:schema entity :listeners mutation]) {})))
 
-(defn unqualify
-  [m]
-  (reduce-kv #(assoc %1 (keyword (name %2)) %3) {} m))
-
 (defn mutate!
   "Perform a mutation. Since mutations are spec'd, parameters are
    expected to conform it."
   ([env mutation params]
    (mutate! env mutation params {}))
   ([env mutation params metadata]
-   {:pre [(s/valid? ::mutate-args [env mutation params])]}
+   (s/assert ::mutate-args [env mutation params])
    (let [{:keys [spec handler]} (find-mutation env mutation)
          listeners              (find-listeners env mutation)]
 
@@ -324,7 +320,6 @@
                     (let [transform (process-transforms-fn (:schema env)
                                                            :serialize)
                           statement (-> (transform params)
-                                        (unqualify)
                                         (handler)
                                         (sql/format))]
                       (jdbc/execute! jdbc statement)))]

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -36,10 +36,9 @@
 
            (mutation :account/update
                      ::account
-                     [{:keys [id] :as params}]
+                     [{:keys [:account/id] :as params}]
                      (-> (h/update :account)
-                         ;; values are fed unqualified
-                         (h/sset (dissoc params :id))
+                         (h/sset (dissoc params :account/id))
                          (h/where [:= :id id]))))
    (entity :user
            (field :id          (ident))
@@ -113,7 +112,7 @@
 
     (testing "inserting additional account"
       (mutate! @store :account/create {:account/name  "a3"
-                                        :account/state :active}))
+                                       :account/state :active}))
 
     (testing "can retrieve account 3"
       (is (= {:account/name  "a3"
@@ -149,11 +148,11 @@
 
       (is (zero? @calls)))
 
-  (testing "removing a listener that was not registered doesn't have side-effects"
-    (reset! calls 0)
-    (swap! store add-listener!    :account/create ::counting-listener4 counting-listener)
-    (swap! store remove-listener! :account/create ::not-registered)
-    (mutate! @store :account/create {:account/name  "a3"
-                                     :account/state :active})
+    (testing "removing a listener that was not registered doesn't have side-effects"
+      (reset! calls 0)
+      (swap! store add-listener!    :account/create ::counting-listener4 counting-listener)
+      (swap! store remove-listener! :account/create ::not-registered)
+      (mutate! @store :account/create {:account/name  "a3"
+                                       :account/state :active})
 
-    (is (= 1 @calls)))))
+      (is (= 1 @calls)))))

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -126,27 +126,34 @@
 
     (testing "can register listener and register is called"
       (reset! calls 0)
-      (swap! store add-listener! :account/create ::counting-listener counting-listener)
+      (swap! store add-listener! :account/create ::counting-listener1 counting-listener)
       (mutate! @store :account/create {:account/name  "a3"
                                        :account/state :active})
+      (swap! store remove-listener! :account/create ::counting-listener1)
       (is (= 1 @calls)))
 
+    (testing "cannot register listener twice with same key"
+      (reset! calls 0)
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (do
+                     (swap! store add-listener! :account/create ::counting-listener2 counting-listener)
+                     (swap! store add-listener! :account/create ::counting-listener2 counting-listener))))
+      (swap! store remove-listener! :account/create ::counting-listener2))
 
     (testing "can remove a listener and register is not called anymore"
       (reset! calls 0)
-      (swap! store add-listener!    :account/create ::counting-listener counting-listener)
-      (swap! store remove-listener! :account/create ::counting-listener)
+      (swap! store add-listener!    :account/create ::counting-listener3 counting-listener)
+      (swap! store remove-listener! :account/create ::counting-listener3)
       (mutate! @store :account/create {:account/name  "a3"
                                        :account/state :active})
 
       (is (zero? @calls)))
 
   (testing "removing a listener that was not registered doesn't have side-effects"
-    (let [listener2 (constantly nil)]
-      (reset! calls 0)
-      (swap! store add-listener!    :account/create ::counting-listener counting-listener)
-      (swap! store remove-listener! :account/create ::not-registered)
-      (mutate! @store :account/create {:account/name  "a3"
-                                       :account/state :active})
+    (reset! calls 0)
+    (swap! store add-listener!    :account/create ::counting-listener4 counting-listener)
+    (swap! store remove-listener! :account/create ::not-registered)
+    (mutate! @store :account/create {:account/name  "a3"
+                                     :account/state :active})
 
-      (is (= 1 @calls))))))
+    (is (= 1 @calls)))))


### PR DESCRIPTION
It's almost always a bug, when it's not the user can just remove-listener! first.
Also clean up tests not to rely on previous test units