### PR TITLE
Ident with alternative table name

### DIFF
--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -48,8 +48,8 @@
 
 (defn add-ident
   "Add a where clause for an ident"
-  [q schema ident arg]
-  (h/merge-where q [:= (table-field (:table schema) ident) arg]))
+  [q entity-name ident arg]
+  (h/merge-where q [:= (table-field entity-name ident) arg]))
 
 (defmulti process-join
   "Process join by relation type. Takes a base query, a map with
@@ -114,7 +114,7 @@
                                 ::fields   []}}
                     fields)
       (some? ident)
-      (add-ident entity-def ident (first args)))))
+      (add-ident entity-name ident (first args)))))
 
 (defn prepare-field
   "Conditionally apply field transform on field id if schema defines

--- a/test/seql/core_test.clj
+++ b/test/seql/core_test.clj
@@ -68,8 +68,14 @@
   (testing "generation of ident selection clause"
     (is (= {:where [:= :user.id "some-uuid"]}
            (c/add-ident {}
-                        (-> env :schema :user)
+                        :user
                         :user/id
+                        "some-uuid"))))
+  (testing "generation of ident selection clause with table name"
+    (is (= {:where [:= :line.id "some-uuid"]}
+           (c/add-ident {}
+                        :line
+                        :line/id
                         "some-uuid")))))
 
 (deftest process-join-test


### PR DESCRIPTION
An invalid `where` clause is generated when a table name is provided. 

The problem can be reproduced with the schema:
```
(def schema
  (entity [:line :invoiceline]
          (field :id  (ident))
          (field :product)
          (field :quantity)))```

And then query:
`(query [:line/id 1])`

The following raw sql query is produced:
`SELECT line.id AS line__id, line.product AS line__product, line.quantity AS line__quantity from invoiceline line WHERE invoiceline.id=?`

That query yields the error: (in postgres)
```
ERROR: invalid reference to FROM-clause entry for table
   "invoiceline" Hint: Perhaps you meant to reference the table alias
   "line".  Position: 121
```

After applying the PR the following query is produced:
`SELECT line.id AS line__id, line.product AS line__product, line.quantity AS line__quantity from invoiceline line WHERE line.id=?`