### PR TITLE
Add preconditions on mutation

### DIFF
--- a/src/seql/spec.clj
+++ b/src/seql/spec.clj
@@ -84,6 +84,14 @@
 (s/def ::handler fn?)
 (s/def ::spec (s/or :kw keyword? :spec s/spec?))
 
+(create-ns 'seql.pre)
+(s/def seql.pre/name string?)
+(s/def seql.pre/handler fn?)
+(s/def seql.pre/valid? fn?)
+(s/def ::pre-condition (s/keys :req-un [:seql.pre/name :seql.pre/handler]
+                               :opt-un [:seql.pre/valid?]))
+(s/def ::pre (s/coll-of ::pre-condition))
+
 (s/def ::table keyword?)
 (s/def ::idents (s/coll-of keyword?))
 (s/def ::fields (s/coll-of keyword?))
@@ -100,7 +108,7 @@
 (s/def ::relation (s/multi-spec relation-dispatch :type))
 (s/def ::relations (s/map-of keyword? ::relation))
 
-(s/def ::mutation (s/keys :req-un [::spec ::handler]))
+(s/def ::mutation (s/keys :req-un [::spec ::handler ::pre]))
 (s/def ::mutations (s/map-of keyword? ::mutation))
 
 (s/def ::compound (s/keys :req-un [::source ::handler]))


### PR DESCRIPTION
These are queries that will run within the same transaction as mutations. They perform select(s) that must conform to a validator or if no validator is supplied return a non empty result. We can have multiple pre conditions for a single mutation, they are tried in order and will cause a rollback/abort of the transaction in case they fail.

It looks like this in the schema: 

```clj
:mutations
{:user/update {:pre [{:name ::u0a0?
                      :valid? (fn [result] ....) ;; optional, defaults to (seq result)
                      :query (fn [user]
                               (-> (h/select :*)
                                   (h/from :user)
                                   (h/where [:= :name "u0a0"]
                                            [:= :id (:user/id user)])))}]
               :handler
               (fn [{:keys [:user/id] :as params}]
                 (-> (h/update :user)
                     (h/sset (dissoc params :user/id))
                     (h/where [:= :id id])))}}}}
```

[ch6406]

