### PR TITLE
Port to next.jdbc

### DIFF
--- a/dataset/db/fixtures.clj
+++ b/dataset/db/fixtures.clj
@@ -1,51 +1,62 @@
 (ns db.fixtures
-  (:require [clojure.java.jdbc  :as jdbc]
+  (:require [next.jdbc          :as jdbc]
+            [next.jdbc.sql      :as sql]
+            [clojure.string     :as str]
             [clojure.java.io    :as io]
             [clojure.edn        :as edn]))
 
-(def jdbc-config
-  {:connection-uri "jdbc:h2:mem:privnet;DB_CLOSE_DELAY=-1"})
+(def jdbc-config "jdbc:h2:mem:privnet;DB_CLOSE_DELAY=-1")
+
+(defn create-table-ddl
+  [table-id cols]
+  (format "CREATE TABLE %s (%s)"
+          (name table-id)
+          (str/join ", "
+                    (map (fn [[id def]] (format "%s %s" (name id) def))
+                            cols))))
 
 (defn cleanup
   []
-  (jdbc/db-do-commands
-   jdbc-config
-   ["DROP TABLE IF EXISTS account"
-    "DROP TABLE IF EXISTS user"
-    "DROP TABLE IF EXISTS invoice"
-    "DROP TABLE IF EXISTS invoiceline"
-    (jdbc/create-table-ddl
-     :account
-     [[:id "int not null auto_increment"]
-      [:name "varchar(32) not null"]
-      [:state "varchar(32) not null"]])
-    (jdbc/create-table-ddl
-     :user
-     [[:id "int not null auto_increment"]
-      [:account_id "int not null"]
-      [:name "varchar(32) not null"]
-      [:email "varchar(32)"]])
-    (jdbc/create-table-ddl
-     :invoice
-     [[:id "int not null auto_increment"]
-      [:account_id "int not null"]
-      [:state "varchar(32) not null"]
-      [:total "int"]])
-    (jdbc/create-table-ddl
-     :invoiceline
-     [[:id "int not null auto_increment"]
-      [:invoice_id "int not null"]
-      [:product "varchar(32) not null"]
-      [:quantity "int"]])]))
+  (run! #(jdbc/execute! jdbc-config [%])
+        ["DROP TABLE IF EXISTS account"
+         "DROP TABLE IF EXISTS user"
+         "DROP TABLE IF EXISTS invoice"
+         "DROP TABLE IF EXISTS invoiceline"
+         (create-table-ddl
+          :account
+          [[:id "int not null auto_increment"]
+           [:name "varchar(32) not null"]
+           [:state "varchar(32) not null"]])
+         (create-table-ddl
+          :user
+          [[:id "int not null auto_increment"]
+           [:account_id "int not null"]
+           [:name "varchar(32) not null"]
+           [:email "varchar(32)"]])
+         (create-table-ddl
+          :invoice
+          [[:id "int not null auto_increment"]
+           [:account_id "int not null"]
+           [:state "varchar(32) not null"]
+           [:total "int"]])
+         (create-table-ddl
+          :invoiceline
+          [[:id "int not null auto_increment"]
+           [:invoice_id "int not null"]
+           [:product "varchar(32) not null"]
+           [:quantity "int"]])]))
 
 (defn load-fixtures
   [dataset]
   (cleanup)
-  (doseq [[k v] (-> (format "db/%s.edn" (name dataset))
+  (doseq [[k [h & r]] (-> (format "db/%s.edn" (name dataset))
                     (io/resource)
                     (slurp)
                     (edn/read-string))]
-    (jdbc/insert-multi! jdbc-config k v)))
+    (sql/insert-multi! jdbc-config
+                       k
+                       h
+                       r)))
 
 (defn with-db-fixtures
   [dataset]

--- a/dataset/db/small.edn
+++ b/dataset/db/small.edn
@@ -1,16 +1,20 @@
-{:account [{:id 0 :name "a0" :state "active"}
-           {:id 1 :name "a1" :state "active"}
-           {:id 2 :name "a2" :state "suspended"}]
- :user [{:id 0 :account_id 0 :name "u0a0" :email "u0@a0"}
-        {:id 1 :account_id 0 :name "u1a0" :email "u1@a0"}
-        {:id 2 :account_id 1 :name "u2a1" :email "u2@a1"}
-        {:id 3 :account_id 1 :name "u3a1" :email "u3@a1"}]
- :invoice [{:id 0 :account_id 0 :state "unpaid" :total 2}
-           {:id 1 :account_id 0 :state "paid" :total 2}
-           {:id 2 :account_id 2 :state "paid" :total 2}
-           {:id 3 :account_id 1 :state "paid" :total 4}]
- :invoiceline [{:id 0 :invoice_id 0 :product "p" :quantity 1}
-               {:id 1 :invoice_id 0 :product "q" :quantity 2}
-               {:id 2 :invoice_id 1 :product "p" :quantity 2}
-               {:id 3 :invoice_id 2 :product "p" :quantity 2}
-               {:id 4 :invoice_id 3 :product "z" :quantity 20}]}
+{:account [[:id :name :state]
+           [0 "a0" "active"]
+           [1 "a1" "active"]
+           [2 "a2" "suspended"]]
+ :user [[:id :account_id :name :email]
+        [0 0 "u0a0" "u0@a0"]
+        [1 0 "u1a0" "u1@a0"]
+        [2 1 "u2a1" "u2@a1"]
+        [3 1 "u3a1" "u3@a1"]]
+ :invoice [[:id :account_id :state :total]
+           [0 0 "unpaid" 2]
+           [1 0 "paid" 2]
+           [2 2 "paid" 2]
+           [3 1 "paid" 4]]
+ :invoiceline [[:id :invoice_id :product :quantity]
+               [0 0 "p" 1]
+               [1 0 "q" 2]
+               [2 1 "p" 2]
+               [3 2 "p" 2]
+               [4 3 "z" 20]]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
-{:deps  {org.clojure/clojure   {:mvn/version "1.10.1"}
-         org.clojure/java.jdbc {:mvn/version "0.7.10"}
-         honeysql              {:mvn/version "0.9.8"}
-         camel-snake-kebab     {:mvn/version "0.4.0"}}
+{:deps  {org.clojure/clojure    {:mvn/version "1.10.1"}
+         seancorfield/next.jdbc {:mvn/version "1.0.9"}
+         honeysql               {:mvn/version "0.9.8"}
+         camel-snake-kebab      {:mvn/version "0.4.0"}}
  :paths ["src"]}

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -1,6 +1,7 @@
 (ns seql.core
   "A way to interact with stored entities"
-  (:require [clojure.java.jdbc      :as jdbc]
+  (:require [next.jdbc              :as jdbc]
+            [next.jdbc.result-set   :as rs]
             [clojure.string         :as str]
             [clojure.spec.alpha     :as s]
             [honeysql.core          :as sql]
@@ -199,11 +200,23 @@
   "Yield a function which processes records and applies predefined
    transforms"
   [schema type]
-  (let [transforms (reduce merge {} (map #(get % :transforms) (vals schema)))
+
+  (let [;; FIXME we could imagine memoizing this,
+        ;; schemas are quite static
+        transforms (into {}
+                         (comp (map val)
+                               (map #(get % :transforms)))
+                         schema)
         extract    (case type :deserialize first :serialize second)]
     (fn [m]
-      (into {} (for [[k v] m :let [transform (extract (get transforms k))]]
-                 [k (cond-> v (and (some? v) (some? transform)) transform)])))))
+      (into {}
+            (map (fn [[k v]]
+                   (let [transform (extract (get transforms k))]
+                     [k (cond-> v
+                          (and (some? v)
+                               (some? transform))
+                          transform)])))
+            m))))
 
 (defn compound-extra-fields
   "Figure out which fields aren't needed once compounds have been
@@ -226,7 +239,11 @@
 (defn process-compounds-fn
   "Yield a schema-specific function to process compounds on the fly"
   [schema {::keys [fields]}]
-  (let [compounds    (reduce merge {} (map :compounds (vals schema)))
+  (let [;; FIXME another one we could memoize
+        compounds    (into {}
+                           (comp (map val)
+                                 (map :compounds))
+                           schema)
         extra-fields (compound-extra-fields compounds fields)]
     (fn [m]
       (->> fields
@@ -261,6 +278,9 @@
                   (reduce (add-relation-fn g) (extract (first g)) relations)))))]
     (walk-tree fields records)))
 
+(defn rs-builder-fn
+  [rs _] (rs/as-lower-maps rs {:label-fn csk/->snake_case}))
+
 (defn query
   "Look up entities."
   ([env entity]
@@ -271,11 +291,13 @@
   ([env entity fields conditions]
    (s/assert ::query-args [env entity fields conditions])
    (let [[q qmeta] (sql-query env entity fields conditions)]
-     (->> (sql/format q)
-          (jdbc/query (:jdbc env))
-          (map qualify-result)
-          (map (process-transforms-fn (:schema env) :deserialize))
-          (map (process-compounds-fn (:schema env) qmeta))
+     (->> (jdbc/plan (:jdbc env) (sql/format q))
+          (into [] (comp
+                    (map qualify-result)
+                    (map (process-transforms-fn (:schema env)
+                                                :deserialize))
+                    (map (process-compounds-fn (:schema env)
+                                               qmeta))))
           (recompose-relations fields)
           (extract-ident entity)))))
 
@@ -300,7 +322,8 @@
 
 (defn success-result?
   [result]
-  (pos? (first result)))
+  (some-> result first :next.jdbc/update-count pos?))
+
 
 (defn mutate!
   "Perform a mutation. Since mutations are spec'd, parameters are
@@ -319,22 +342,21 @@
                        {:type    :error/illegal-argument
                         :code    400
                         :explain (s/explain-str spec params)})))
-
      (let [transform (process-transforms-fn (:schema env)
                                             :serialize)
            transformed-params (transform params)
            statement (-> transformed-params
                          (handler)
                          (sql/format))
-           result (jdbc/with-db-transaction [jdbc (:jdbc env)]
+           result (jdbc/with-transaction [jdbc (:jdbc env)]
                     ;; if we have preconditions check these first
                     (when (seq pre)
                       (run! (fn [{:keys [name query valid?]
                                   :or {valid? seq}}]
-                              (let [result (jdbc/query jdbc
-                                                       (-> transformed-params
-                                                           (query)
-                                                           (sql/format)))]
+                              (let [result (jdbc/execute! jdbc
+                                                          (-> transformed-params
+                                                              (query)
+                                                              (sql/format)))]
                                 (when-not (valid? result)
                                   (throw (ex-info (format "Precondition %s on mutation %s failed"
                                                           name
@@ -346,7 +368,6 @@
                                                    :params params})))))
                             pre))
                     (jdbc/execute! jdbc statement))]
-
        (when-not (success-result? result)
          (throw (ex-info (format "the mutation has failed: %s" mutation)
                          {:type     :error/mutation-failed
@@ -362,6 +383,7 @@
                           :params   params
                           :metadata metadata}))
              listeners)
+
        result))))
 
 ;; Environment modifiers

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -278,9 +278,6 @@
                   (reduce (add-relation-fn g) (extract (first g)) relations)))))]
     (walk-tree fields records)))
 
-(defn rs-builder-fn
-  [rs _] (rs/as-lower-maps rs {:label-fn csk/->snake_case}))
-
 (defn query
   "Look up entities."
   ([env entity]

--- a/test/seql/readme_test.clj
+++ b/test/seql/readme_test.clj
@@ -272,5 +272,5 @@
         (mutate! env :account/create {:account/name "a4" :account/state :active})
 
         (is (= {:mutation :account/create
-                :result   [1]}
+                :result   [{:next.jdbc/update-count 1}]}
                @last-result))))))


### PR DESCRIPTION
It's a first stab at it. I probably didn't use all the new options from .next yet but I already applied a few improvements like fusing part of the result transforms. Something I didn't do is take advantage of is builder-fn to create entity col names labels on the fly, it still uses the legacy code.
It's quite conservative since we're relying on seql quite a bit, I didn't want to take too many risks for a first step.

One important diff would be the way update success is indicated, we should favor using the function I added for this instead of the [1] value like in the past. 
Also the way the config is specified changed, as seen in https://github.com/exoscale/seql/pull/10/commits/d624f4984bb3165dd88939f7d00541ddbb8d89b3#diff-85435b9b2af513f2ef158094336b73d7L6
Another minor change would be that ddl functions are gone and the fixture format is different.


refs #3 