### PR TITLE
merge original precond with ex

### DIFF
--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -349,7 +349,8 @@
                     ;; if we have preconditions check these first
                     (when (seq pre)
                       (run! (fn [{:keys [name query valid?]
-                                  :or {valid? seq}}]
+                                  :or {valid? seq}
+                                  :as pre}]
                               (let [result (jdbc/execute! jdbc
                                                           (-> transformed-params
                                                               (query)

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -361,8 +361,8 @@
                                                   {:type :error/mutation-failed
                                                    :code 409
                                                    :mutation mutation
-                                                   :pre name
-                                                   :params params})))))
+                                                   :params params
+                                                   :pre (dissoc pre :valid? :query)})))))
                             pre))
                     (jdbc/execute! jdbc statement))]
        (when-not (success-result? result)


### PR DESCRIPTION
That could be handy to specify extra data per context on the :pre map that could be re-used in case of failure in a generic way (ex custom error messages)