### PR TITLE
 infer coercion of input params in mutations via spec-coerce

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:deps  {org.clojure/clojure    {:mvn/version "1.10.1"}
          seancorfield/next.jdbc {:mvn/version "1.0.9"}
          honeysql               {:mvn/version "0.9.8"}
-         camel-snake-kebab      {:mvn/version "0.4.0"}}
+         camel-snake-kebab      {:mvn/version "0.4.0"}
+         spec-coerce            {:mvn/version "1.0.0-alpha14"}}
  :paths ["src"]}

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -7,6 +7,7 @@
             [honeysql.core          :as sql]
             [honeysql.helpers       :as h]
             [camel-snake-kebab.core :as csk]
+            [spec-coerce.core       :as sc]
             [seql.spec]))
 
 ;; SQL Query Builder
@@ -358,8 +359,8 @@
   ([env mutation params metadata]
    (s/assert ::mutate-args [env mutation params])
    (let [{:keys [spec handler pre]} (find-mutation env mutation)
-         listeners                  (find-listeners env mutation)]
-
+         listeners                  (find-listeners env mutation)
+         params                     (sc/coerce spec params)]
      (when-not (s/valid? spec params)
        (throw (ex-info (format "mutation params do not conform to %s: %s"
                                spec

--- a/test/seql/core_test.clj
+++ b/test/seql/core_test.clj
@@ -1,7 +1,7 @@
 (ns seql.core-test
   (:require [seql.core    :as c]
             [seql.helpers :refer [make-schema ident field compound
-                                  mutation transform has-many has-one condition
+                                  transform has-many has-one condition
                                   entity]]
             [clojure.test :refer [use-fixtures testing deftest is]]
             [db.fixtures  :refer [with-db-fixtures]]))

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -107,6 +107,7 @@
 
   (testing "can update account 3 with spec-coerce coercion"
     (mutate! env :account/update {:account/id    3
+                                  :account/name  "new name"
                                   :account/state "active"}))
 
   (testing "throw if an non-existing account is updated"

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -105,6 +105,10 @@
                                   :account/state :active
                                   :account/name  "new name"}))
 
+  (testing "can update account 3 with spec-coerce coercion"
+    (mutate! env :account/update {:account/id    3
+                                  :account/state "active"}))
+
   (testing "throw if an non-existing account is updated"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo


### PR DESCRIPTION
This infers the mutation of input params via spec-coerce using the spec defined for the mutation.

ch11278