### PR TITLE
spec-coerce based transformations

### DIFF
--- a/dataset/db/fixtures.clj
+++ b/dataset/db/fixtures.clj
@@ -77,6 +77,7 @@
 (defn with-db-fixtures
   [dataset]
   (fn [f]
+    (cleanup)
     (load-fixtures dataset)
     (f)
     (cleanup)))

--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,5 @@
          seancorfield/next.jdbc {:mvn/version "1.0.9"}
          honeysql               {:mvn/version "0.9.8"}
          camel-snake-kebab      {:mvn/version "0.4.0"}
-         exoscale/coax          {:mvn/version "0.1.1"}}
+         exoscale/coax          {:mvn/version "0.1.2"}}
  :paths ["src"]}

--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,5 @@
          seancorfield/next.jdbc {:mvn/version "1.0.9"}
          honeysql               {:mvn/version "0.9.8"}
          camel-snake-kebab      {:mvn/version "0.4.0"}
-         spec-coerce            {:mvn/version "1.0.0-alpha15"}}
+         exoscale/coax          {:mvn/version "0.1.1"}}
  :paths ["src"]}

--- a/src/seql/coerce.clj
+++ b/src/seql/coerce.clj
@@ -1,0 +1,56 @@
+(ns seql.coerce
+  "Handling of field coercion for read/write"
+  (:refer-clojure :exclude [read])
+  (:require [clojure.edn :as edn]
+            [clojure.spec.alpha :as s]
+            [exoscale.coax :as sc]))
+
+(def spec-registry (atom {::reader {}
+                          ::writer {}}))
+
+(defn edn-reader [x _] (edn/read-string x))
+(defn edn-writer [x _] (pr-str x))
+
+(defn -register-rw!
+  [type spec-key coercer]
+  (swap! spec-registry
+         assoc-in [type spec-key] coercer))
+
+(defn with-writer!
+  "Registers a writer for `spec`"
+  [spec-key w]
+  (-register-rw! ::writer spec-key w)
+  spec-key)
+
+(defn with-reader!
+  "Registers a reader for `spec`"
+  [spec-key w]
+  (-register-rw! ::reader spec-key w)
+  spec-key)
+
+(def pred-writer-registry
+  (atom {`keyword? (fn [x _] (name x))}))
+
+(defn write
+  "Infer from field spec if we need to use ::overrides or just a
+  predicate registered transform. Suports Set spec types inference and
+  nilables"
+  [k v]
+  (let [rs (some-> k
+                   s/get-spec
+                   s/form) ; get original spec form
+        s (sc/pull-nilable rs) ; in case it's nilable pull original form
+        f (get @pred-writer-registry ; find writer for original form
+               (cond-> s
+                 (sc/spec-is-homogeneous-set? s)
+                 (-> first sc/type->sym)))]
+    (if (ifn? f) ; we got a custom writer
+      (if (sc/nilable-spec? rs)
+        ((sc/gen-nilable-coercer f) v nil) ; if nilable we must make the coercer aware
+        (f v nil))
+      (sc/coerce k v {::sc/overrides (::writer @spec-registry)}))))
+
+(defn read
+  "Infer from specs+ reader registry now to read value of attribute `k`"
+  [k v]
+  (sc/coerce k v {::sc/overrides (::reader @spec-registry)}))

--- a/src/seql/helpers.clj
+++ b/src/seql/helpers.clj
@@ -32,7 +32,7 @@
   {:keyword [keyword name]
    :edn     [edn/read-string pr-str]})
 
-(defn transform
+(defn ^:deprecated transform
   "Provide transformation for the field. Transformations
    can either be a keyword, pointing to a known transformation
    (see `transforms` for details), or a tuple of

--- a/test/seql/coerce_test.clj
+++ b/test/seql/coerce_test.clj
@@ -1,0 +1,34 @@
+(ns seql.coerce-test
+  (:require [clojure.test :as t :refer [deftest is]]
+            [clojure.spec.alpha :as s]
+            [seql.coerce :as c]))
+
+(s/def ::k keyword?)
+(s/def ::kxs #{:foo :bar :baz})
+
+(s/def ::i integer?)
+(s/def ::ixs #{1 2 3})
+
+(s/def ::m map?)
+
+(deftest test-writer
+  (is (= (c/write ::unknown-spec 1) 1))
+  (is (= (c/write nil 1) 1))
+  (is (= (c/write ::k :foo) "foo"))
+  (is (= (c/write ::k :foo) "foo"))
+  (is (= (c/write ::m {:a 1}) {:a 1}))
+
+  (-> (s/def ::mw map?)
+      (c/with-writer! c/edn-writer))
+
+  (is (= (c/write ::mw {:a 1}) "{:a 1}")))
+
+(deftest test-reader
+  (is (= (c/read ::unknown-spec 1) 1))
+  (is (= (c/read nil 1) 1))
+  (is (= (c/read ::k "foo") :foo))
+  (is (= (c/read ::m {:a 1}) {:a 1}))
+  (-> (s/def ::mw map?)
+      (c/with-reader! c/edn-reader))
+
+  (is (= (c/read ::mw "{:a 1}") {:a 1})))

--- a/test/seql/condition_test.clj
+++ b/test/seql/condition_test.clj
@@ -7,7 +7,10 @@
   the appropriate where vector for honeysql.
   "
   (:require [seql.core     :refer :all]
-            [clojure.test  :refer :all]))
+            [clojure.test  :refer :all]
+            [clojure.spec.alpha :as s]))
+
+(s/def :a/state #{:active :suspended})
 
 (deftest condition-test
   (let [empty-query {}

--- a/test/seql/helpers_schema_test.clj
+++ b/test/seql/helpers_schema_test.clj
@@ -7,7 +7,7 @@
    (entity :account
            (field :id          (ident))
            (field :name        (ident))
-           (field :state       (transform :keyword))
+           (field :state)
            (has-many :users    [:id :user/account-id])
            (has-many :invoices [:id :invoice/account-id])
 
@@ -21,7 +21,7 @@
 
    (entity :invoice
            (field :id          (ident))
-           (field :state       (transform :keyword))
+           (field :state)
            (field :total)
            (compound :paid?    [state] (= state :paid))
            (has-many :lines    [:id :line/invoice-id])
@@ -38,7 +38,6 @@
   {:account {:table      :account
              :idents     [:account/id :account/name]
              :fields     [:account/id :account/name :account/state]
-             :transforms {:account/state [keyword name]}
              :conditions {:account/active {:type  :static
                                            :field :account/state
                                            :value :active}
@@ -55,7 +54,6 @@
    :invoice {:table      :invoice
              :idents     [:invoice/id]
              :fields     [:invoice/id :invoice/state :invoice/total]
-             :transforms {:invoice/state [keyword name]}
              :conditions {:invoice/unpaid {:type  :static
                                            :field :invoice/state
                                            :value :unpaid}
@@ -105,18 +103,8 @@
 
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
-         #"The transform form should be used inside field definitions"
-         (make-schema (transform :keyword))))
-
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
          #"The ident form should be used inside field definitions"
          (entity :example (ident))))
-
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #"The transform form should be used inside field definitions"
-         (entity :example (transform :keyword))))
 
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
@@ -138,6 +126,16 @@
          #"The compound form should be used inside entity definitions"
          (make-schema
           (compound :paid? [state] (= state :paid)))))
+
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"The transform form should be used inside field definitions"
+         (make-schema (transform :keyword))))
+
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"The transform form should be used inside field definitions"
+         (entity :example (transform :keyword))))
 
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -2,7 +2,7 @@
   (:require [seql.core          :refer [query mutate!
                                         add-listener! remove-listener!]]
             [seql.helpers       :refer [make-schema ident field compound
-                                        mutation transform has-many has-one condition
+                                        mutation has-many has-one condition
                                         has-many-through
                                         entity]]
             [db.fixtures        :refer [jdbc-config with-db-fixtures]]
@@ -22,7 +22,7 @@
    (entity :account
            (field :id          (ident))
            (field :name        (ident))
-           (field :state       (transform :keyword))
+           (field :state)
            (has-many :users    [:id :user/account-id])
            (has-many :invoices [:id :invoice/account-id])
 
@@ -47,7 +47,7 @@
            (field :email))
    (entity :invoice
            (field :id          (ident))
-           (field :state       (transform :keyword))
+           (field :state)
            (field :total)
            (compound :paid?    [state] (= state :paid))
            (has-many :lines    [:id :line/invoice-id])


### PR DESCRIPTION
We now have spec based coercion inference, we'll have spec-coerce transform input to send to the db the way we want for 99% of the cases (keyword? uuid? etc). 

That means in practice that if/when you declare a spec for your fields we will know how to marshal values in/out of the db automagically.

That also works when we read from the db, we'll spec-coerce/coerce column values to what they should be, so uuid?s will get turned from string to uuids and so on. 

This works everywhere: conditions, results, parameters, mutations.

We provide also a way to supply `overrides` for fields we want to handle differently from the defaults via `seql.coerce/with-reader` `seql.coerce/with-writer` on the spec directly. 

Typical example to serialize a field as edn: 
https://github.com/exoscale/seql/compare/feature/spec-coerce?expand=1#diff-8ffc104ac863cae2d2a9a7c494bc23fbR21-R22. 

spec-coerce out of the box allows to specify overrides via 
```clj
(sc/coerce ::foo thing {::sc/overrides {::bar (fn [val opts] <transform data here>)}})
```
So the same way spec allows to specify custom generators, with one caveat, ::overrides must be qualified keys, so declared specs. Because of that I added a small internal registry of predicates we support of the box for **writing** with the fields that would need special handling from specs such as `(s/def ::foo keyword?) (s/def ::foo #{:a :b})`. 

The tldr: you can throwaway all your :transforms, and for "edn" blob fields you have to move to `seql.coerce/with-` on your specs. 

potential improvement we could also do more inference for the edn blob fields, but that's for another pr likely.

