### PR TITLE
Make sure we cleanup rows with empty relations early

### DIFF
--- a/dataset/db/fixtures.clj
+++ b/dataset/db/fixtures.clj
@@ -41,6 +41,7 @@
           [[:id "int not null auto_increment"]
            [:account_id "int not null"]
            [:state "varchar(32) not null"]
+           [:name "varchar(32)"]
            [:total "int"]])
          (create-table-ddl
           :product

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -16,6 +16,8 @@
 (s/def :account/state keyword?)
 (s/def ::account (s/keys :req [:account/name :account/state]))
 
+(s/def :invoice/name string?)
+
 (def schema
   "As gradually explained in the project's README"
   (make-schema
@@ -48,6 +50,7 @@
    (entity :invoice
            (field :id          (ident))
            (field :state)
+           (field :name)
            (field :total)
            (compound :paid?    [state] (= state :paid))
            (has-many :lines    [:id :line/invoice-id])
@@ -82,6 +85,7 @@
            (query env
                   [:account/name "a3"]
                   [:account/name {:account/invoices [:invoice/id
+                                                     :invoice/name
                                                      :invoice/state]}])))))
 
 (deftest insert-account-test

--- a/test/seql/relation_test.clj
+++ b/test/seql/relation_test.clj
@@ -109,27 +109,4 @@
                           {:b/id 5 :b/c [{:c/id 15} {:c/id 16} {:c/id 17}]}]}]]
 
       (is (= result (recompose-relations {}  fields records)))
-      (is (= result (recompose-relations {}  fields (shuffle records))))))
-
-  (testing "weeding out empty nested entities"
-
-    ;; When doing left joins we have cases where no sub entity exists
-    ;; in this case, ensure that they get weeded out of the output list
-
-    (let [records [{:a 1 :b 4 :c nil}
-                   {:a 1 :b 5 :c nil}
-                   {:a 1 :b 6 :c nil}
-                   {:a 2 :b nil :c nil}]
-          fields [:a {:b [:b]} {:c [:c]}]
-          result [{:a 1 :b [{:b 4} {:b 5} {:b 6}] :c []}
-                  {:a 2 :b []                     :c []}]]
-
-      (is (= result (recompose-relations {} fields (shuffle records)))))
-
-    (let [records [{:a 4 :b nil :c 1}
-                   {:a 3 :b 7 :c 2}
-                   {:a 3 :b 8 :c 2}]
-          fields [:a {:b [:b]} {:c [:c]}]
-          result [{:a 3 :b [{:b 7} {:b 8}] :c [{:c 2}]}
-                  {:a 4 :b []              :c [{:c 1}]}]]
       (is (= result (recompose-relations {}  fields (shuffle records)))))))


### PR DESCRIPTION
It has to happen before coercion otherwise we cannot detect empty
relations fields since (c/read string? nil) -> "" (and potentially others). 

This would also have been bugged previously with transformers that are not careful with nils potentially.

Instead of building a relations maps after coercion and then removing the maps with all nil values we deal with it early when the result set is build and remove all cols that are part of a relation that has only nils for that entity/rel-type.