### PR TITLE
Add support for SQL IN queries in conditions

### DIFF
--- a/test/seql/condition_test.clj
+++ b/test/seql/condition_test.clj
@@ -41,12 +41,12 @@
     (testing "field conditions must respect arity"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"bad arity for field condition: :a/state"
-                            (add-condition schema empty-query [:a/state])))
+                            (add-condition schema empty-query [:a/state]))))
 
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"bad arity for field condition: :a/state"
-                            (add-condition schema empty-query
-                                           [:a/state "active" "suspended"]))))
+    (testing "adding multiple fields creates a :in clause"
+      (is (= {:where [:in :a.state ["active" "suspended"]]}
+             (add-condition schema empty-query
+                            [:a/state "active" "suspended"]))))
 
     (testing "function conditions must respect arity"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/test/seql/integration_test.clj
+++ b/test/seql/integration_test.clj
@@ -158,9 +158,13 @@
                                              #:user{:name "u1a0"}]}
              (query @store [:role/id 0] [:role/name {:role/users [:user/name]}]))))
 
-    (testing "two accounts are active"
+    (testing "three accounts are active"
       (is (= [{:account/name "a0"} {:account/name "a1"} {:account/name "a3"}]
              (query @store :account [:account/name] [[:account/active]]))))
+
+    (testing "get active and suspended accounts"
+      (is (= [{:account/name "a0"} {:account/name "a1"} #:account{:name "a2"} {:account/name "a3"}]
+             (query @store :account [:account/name] [[:account/state :active :suspended]]))))
 
     (testing "unpaid invoices"
       (is (= [{:invoice/total 2


### PR DESCRIPTION
Currently, passing more than one argument to conditions of type
:field causes an error. But we often need to match a field on
various values. It can be done server side (get all + filtering) but
this can cause performance issues.

This commit modifies the :field condition to support multiple
parameters. If multiple parameters are provided, the where clause will
be a `IN` on all parameters.