### PR TITLE
Conditions: use the right table name

### DIFF
--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -156,13 +156,12 @@
   "If conditions are provided, add them to the query"
   [schema q [condition & args]]
   (let [entity (-> condition namespace keyword)
-        table  (get-in schema [entity :table])
         params (get-in schema [entity :conditions condition])
         type   (:type params)
         field  (:field params)]
     (cond
       (= type :static)
-      (h/merge-where q [:= (table-field table (:field params))
+      (h/merge-where q [:= (table-field entity (:field params))
                         (->> (c/write field (:value params))
                              (prepare-field schema field))]) ; backward compat transforms
 
@@ -173,11 +172,11 @@
                            :code      400
                            :condition condition
                            :args      args}))
-        1 (h/merge-where q [:= (table-field table field)
+        1 (h/merge-where q [:= (table-field entity field)
                             (->> (c/write field
                                           (first args))
                                  (prepare-field schema field))])
-        (h/merge-where q [:in (table-field table field)
+        (h/merge-where q [:in (table-field entity field)
                           (->> (map #(c/write field %) args)
                                (map #(prepare-field schema field %)))]))
 

--- a/test/seql/condition_test.clj
+++ b/test/seql/condition_test.clj
@@ -8,6 +8,7 @@
   "
   (:require [seql.core     :refer :all]
             [clojure.test  :refer :all]
+            [honeysql.core :as sql]
             [clojure.spec.alpha :as s]))
 
 (s/def :a/state #{:active :suspended})
@@ -57,3 +58,62 @@
       (is (= {:where [:= :a.field "value"]}
              (add-condition schema empty-query
                             [:a/inline :a.field "value"]))))))
+
+(deftest condition-table-alias-test
+  (let [empty-query {}
+        schema      {:a {:table      :b
+                         :ident      :a/id
+                         :fields     [:a/id :a/state :a/name]
+                         :conditions {:a/active {:type  :static
+                                                 :field :a/state
+                                                 :value :active}
+                                      :a/state  {:type  :field
+                                                 :field :a/state}
+                                      :a/inline {:type    :fn
+                                                 :arity   2
+                                                 :handler #(vector := %1 %2)}}
+                         :transforms {:a/state [keyword name]}}}]
+
+    (testing "adding static condition"
+      (is (= {:where [:= :a.state "active"]}
+             (add-condition schema empty-query [:a/active]))))
+
+    (testing "adding field condition"
+      (is (= {:where [:= :a.state "active"]}
+             (add-condition schema empty-query [:a/state :active])))
+
+      (is (= {:where [:= :a.state "suspended"]}
+             (add-condition schema empty-query [:a/state :suspended]))))
+
+    (testing "field conditions must respect arity"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"bad arity for field condition: :a/state"
+                            (add-condition schema empty-query [:a/state]))))
+
+    (testing "adding multiple fields creates a :in clause"
+      (is (= {:where [:in :a.state ["active" "suspended"]]}
+             (add-condition schema empty-query
+                            [:a/state "active" "suspended"]))))
+
+    (testing "function conditions must respect arity"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"bad arity for condition: :a/inline"
+                            (add-condition schema empty-query [:a/inline]))))
+
+    (testing "function conditions are executed"
+      (is (= {:where [:= :a.field "value"]}
+             (add-condition schema empty-query
+                            [:a/inline :a.field "value"]))))))
+
+(deftest condition-alias-sql-test
+  (let [schema {:a {:table      :b
+                    :ident      :a/id
+                    :fields     [:a/id :a/state]
+                    :conditions {:a/active {:type  :static
+                                            :field :a/state
+                                            :value :active}}
+                    :transforms {:a/state [keyword name]}}}]
+    (is (= ["SELECT a.id AS a__id FROM b a  WHERE a.state = ?" "active"]
+           (-> (sql-query {:schema schema} :a [:a/id] [[:a/active]])
+               (first)
+               (sql/format))))))

--- a/test/seql/readme_test.clj
+++ b/test/seql/readme_test.clj
@@ -44,7 +44,6 @@
                         (condition :active :state :active)
                         (condition :state)))
         env     {:schema schema :jdbc jdbc-config}]
-
     (testing "ID lookups work"
       (is (= #:account{:name "a0" :state :active}
              (query env [:account/name "a0"] [:account/name :account/state]))))


### PR DESCRIPTION
The table name should always be the entity name in conditions.

fix https://github.com/exoscale/seql/issues/33