### PR TITLE
Exclude secrets from sort-fn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,6 @@
          seancorfield/next.jdbc {:mvn/version "1.1.588"}
          honeysql               {:mvn/version "0.9.8"}
          camel-snake-kebab      {:mvn/version "0.4.0"}
-         exoscale/coax          {:mvn/version "1.0.0-alpha7"}}
+         exoscale/coax          {:mvn/version "1.0.0-alpha7"}
+         exoscale/cloak         {:mvn/version "0.1.6"}}
  :paths ["src"]}

--- a/src/seql/core.clj
+++ b/src/seql/core.clj
@@ -6,6 +6,7 @@
             [honeysql.core          :as sql]
             [honeysql.helpers       :as h]
             [exoscale.coax          :as sc]
+            [exoscale.cloak         :as cloak]
             [seql.coerce            :as c]
             [seql.spec]
             [seql.string :as seql-str]))
@@ -301,7 +302,7 @@
   in order to not use them in the comparison."
   [fields]
   (comp vec
-        (fn [f] (map #(if (map? %)
+        (fn [f] (map #(if (or (map? %) (cloak/secret? %))
                         nil
                         %)
                      f))


### PR DESCRIPTION
Secrets are causing issues in seql when used in partition-by.
This commit removes the field if it's a secret.