### PR TITLE
Allow to use any schema validation library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
                          :pedantic?      :warn
                          :source-paths   ["dataset"]
                          :resource-paths ["dataset"]}
+               :test {:dependencies [[metosin/malli "0.2.1"]]}
                :uberjar {:pedantic? :abort}}
     :dependencies ~deps
     :source-paths ~paths))

--- a/src/seql/coerce.clj
+++ b/src/seql/coerce.clj
@@ -3,7 +3,27 @@
   (:refer-clojure :exclude [read])
   (:require [clojure.edn :as edn]
             [clojure.spec.alpha :as s]
-            [exoscale.coax :as c]))
+            [exoscale.coax :as c]
+            [exoscale.coax :as sc]))
+
+(defprotocol Coercion
+  (get-name [this])
+  (get-coercer [this spec])
+  (get-validater [this spec])
+  (get-explainer [this spec]))
+
+(def default-coercion
+  (reify Coercion
+    (get-name [_] :spec)
+    (get-coercer [_ spec]
+      (fn [value]
+        (sc/coerce spec value)))
+    (get-validater [_ spec]
+      (fn [value]
+        (s/valid? spec value)))
+    (get-explainer [_ spec]
+      (fn [value]
+        (s/explain-str spec value)))))
 
 (def spec-registry (atom {::reader {}
                           ::writer {::c/idents {`keyword? (fn [x _] (name x))}}}))

--- a/src/seql/spec.clj
+++ b/src/seql/spec.clj
@@ -125,8 +125,11 @@
 
 (s/def :seql.core/jdbc any?)
 
+(s/def :seql.core/coercion instance?)
+
 (s/def :seql.core/env
-  (s/keys :req-un [:seql.core/schema :seql.core/jdbc]))
+  (s/keys :req-un [:seql.core/schema :seql.core/jdbc]
+          :opt-un [:seql.core/coercion]))
 
 (s/def :seql.core/condition (s/cat :name keyword? :args (s/* any?)))
 


### PR DESCRIPTION
The purpose of this PR is to allow to use any schema validation library like [schema](https://github.com/plumatic/schema) or [malli](https://github.com/metosin/malli)

The default library stay `clojure.spec` so this PR must not break anything!