### PR TITLE
Support mariadb

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,5 +17,5 @@
   :aliases {"coverage" ["with-profile" "+test" "cloverage"]}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [com.github.seancorfield/next.jdbc "1.2.737"]
-                 [com.github.seancorfield/honeysql "2.1.818"]
+                 [com.github.seancorfield/honeysql "2.7.1364"]
                  [exoscale/coax "2.0.0"]])

--- a/src/seql/params.clj
+++ b/src/seql/params.clj
@@ -13,7 +13,8 @@
             (into [] cat (map extract-fields l)))
           (extract-fields [[k v]]
             (case k
-              :field    [(schema/resolve-field schema v)]
+              :field    [[(schema/resolve-field schema v)
+                          (schema/resolve-field-alias schema v)]]
               :relation (list-extract-fields (first (vals v)))))]
     (list-extract-fields q)))
 

--- a/src/seql/result_set.clj
+++ b/src/seql/result_set.clj
@@ -10,9 +10,7 @@
   "Reverse lookup of column name for rows."
   [schema ^ResultSetMetaData rsmeta]
   (mapv (fn [^Integer i]
-          (schema/unresolve-column schema
-                                   (.getTableName rsmeta i)
-                                   (.getColumnLabel rsmeta i)))
+          (schema/unresolve-column-by-alias schema (.getColumnLabel rsmeta i)))
         (range 1 (inc (if rsmeta (.getColumnCount rsmeta) 0)))))
 
 (defn builder-fn

--- a/src/seql/schema.clj
+++ b/src/seql/schema.clj
@@ -91,6 +91,16 @@
             (name override)
             (->snake_case_string (name field)))))))
 
+(defn resolve-field-alias
+  [schema field]
+  (let [table (resolve-table schema field)]
+    (keyword
+     (str (name table)
+          ","
+          (if-let [override (resolve-override schema field)]
+            (name override)
+            (->snake_case_string (name field)))))))
+
 (defn resolve-fields
   "Resolves known fields from a schema"
   [schema kw]
@@ -131,6 +141,20 @@
                      :when (= (str/lower-case field) (str/lower-case (name v)))]
                  k))
         (keyword entity (->kebab-case-string field)))))
+
+(defn unresolve-column-by-alias
+  "Figure out a field name based on a table and column name in SQL."
+  [schema table-and-field]
+  (let [parts (str/split table-and-field #",")]
+    (when (= 2 (count parts))
+      (let [table  (first parts)
+            field  (second parts)
+            entity (unresolve-table schema table)]
+        (or (first
+             (for [[k v] (resolve-by-entity schema (keyword entity) :overrides)
+                   :when (= (str/lower-case field) (str/lower-case (name v)))]
+               k))
+            (keyword entity (->kebab-case-string field)))))))
 
 ;; I wonder if this belongs here, maybe in coerce?
 (defn as-column-name

--- a/test/seql/params_condition_test.clj
+++ b/test/seql/params_condition_test.clj
@@ -102,5 +102,5 @@
                     :conditions {:a/active {:type  :static
                                             :field :a/state
                                             :value :active}}}}]
-    (is (= ["SELECT b.id FROM b WHERE b.state = ?" "active"]
+    (is (= ["SELECT b.id AS \"b,id\" FROM b WHERE b.state = ?" "active"]
            (sql-format schema :a [:a/id] [[:a/active]])))))

--- a/test/seql/params_query_test.clj
+++ b/test/seql/params_query_test.clj
@@ -19,7 +19,7 @@
       {:table      :a
        :fields     [:a/id]
        :ident?     false
-       :selections [:a.id]
+       :selections [[:a.id (keyword "a,id")]]
        :conditions nil
        :joins      []}
       :a/a [:a/id] []
@@ -27,7 +27,7 @@
       {:table      :a
        :fields     [:a/id]
        :ident?     true
-       :selections [:a.id]
+       :selections [[:a.id (keyword "a,id")]]
        :conditions [[:= :a.id 0]]
        :joins      []}
       [:a/id 0] [:a/id] []
@@ -35,7 +35,7 @@
       {:table      :a
        :fields     [:a/id {:a/b [:b/id]}]
        :ident?     true
-       :selections [:a.id :b.id]
+       :selections [[:a.id (keyword "a,id")] [:b.id (keyword "b,id")]]
        :conditions [[:= :a.id 0] [:= :b.name "foo"]]
        :joins      [:a/b]}
       [:a/id 0] [:a/id {:a/b [:b/id]}] [[:b/name "foo"]])))

--- a/test/seql/params_test.clj
+++ b/test/seql/params_test.clj
@@ -19,10 +19,10 @@
 (deftest find-selections-test
   (testing "field extraction"
     (are [x y] (= x (find-selections abc-schema y))
-      [:a.id]             [:a/id]
-      [:a.id :a.name]     [:a/id :a/name]
-      [:a.id :b.id]       [:a/id {:a/b [:b/id]}]
-      [:a.id :b.id :x.id] [:a/id {:a/b [:b/id {:b/c [:c/id]}]}])))
+      [[:a.id (keyword "a,id")]]                                                   [:a/id]
+      [[:a.id (keyword "a,id")] [:a.name (keyword "a,name")]]                      [:a/id :a/name]
+      [[:a.id (keyword "a,id")] [:b.id (keyword "b,id")]]                          [:a/id {:a/b [:b/id]}]
+      [[:a.id (keyword "a,id")] [:b.id (keyword "b,id")] [:x.id (keyword "x,id")]] [:a/id {:a/b [:b/id {:b/c [:c/id]}]}])))
 
 (deftest find-joins-test
   (testing "join extraction"

--- a/test/seql/sql_test.clj
+++ b/test/seql/sql_test.clj
@@ -27,16 +27,16 @@
                     :fields [:c/id]}}]
 
     (testing "basic single-layer query"
-      (is (= "SELECT a.id FROM a"
+      (is (= "SELECT a.id AS \"a,id\" FROM a"
              (sql-format schema :a [:a/id] []))))
 
     (testing "query for one nested entity"
-      (is (= (str "SELECT a.id, b.id "
+      (is (= (str "SELECT a.id AS \"a,id\", b.id AS \"b,id\" "
                   "FROM a LEFT JOIN b ON a.id = b.a_id")
              (sql-format schema :a [:a/id {:a/b [:b/id]}] []))))
 
     (testing "query for a two-level nested entity"
-      (is (= (str "SELECT a.id, b.id, c.id "
+      (is (= (str "SELECT a.id AS \"a,id\", b.id AS \"b,id\", c.id AS \"c,id\" "
                   "FROM a LEFT JOIN b ON a.id = b.a_id "
                   "LEFT JOIN c ON b.id = c.b_id")
              (sql-format schema :a [:a/id {:a/b [:b/id {:b/c [:c/id]}]}] []))))))
@@ -61,8 +61,8 @@
                     :fields [:i/id :i/a-id :i/b-id]}}]
 
     (testing "basic single-layer query"
-      (is (= "SELECT a.id FROM a" (sql-format schema :a [:a/id] []))))
+      (is (= "SELECT a.id AS \"a,id\" FROM a" (sql-format schema :a [:a/id] []))))
 
     (testing "many-to-many query"
-      (is (= "SELECT a.id, b.id FROM a LEFT JOIN i ON a.id = i.a_id LEFT JOIN b ON i.b_id = b.id"
+      (is (= "SELECT a.id AS \"a,id\", b.id AS \"b,id\" FROM a LEFT JOIN i ON a.id = i.a_id LEFT JOIN b ON i.b_id = b.id"
              (sql-format schema :a [:a/id {:a/b [:b/id]}] []))))))


### PR DESCRIPTION
Add MariaDB compatibility by using column aliases instead of relying on JDBC `ResultSetMetaData.getTableName()`.

# Problem

MariaDB's JDBC driver does not reliably return table names via `ResultSetMetaData.getTableName()`, which SEQL relied on to map result columns back to qualified entity fields. This caused result set parsing to fail on MariaDB.

# Solution

- Generate explicit column aliases in the format table,column (e.g., `SELECT a.id AS "a,id"`)
- Parse the alias to determine the source table and column when building result maps
- Added `resolve-field-alias` and `unresolve-column-by-alias` functions in schema.clj
- Updated `find-selections` in params.clj to return `[field alias]` tuples for HoneySQL
- Simplified result_set.clj to use alias-based column resolution

# Dependencies
Updated HoneySQL from 2.1.818 to 2.7.1364